### PR TITLE
白樂祺(PAI LE-CHI) - 面試

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.11-slim
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 RUN apt-get update && apt-get install -y postgresql-client

--- a/api/models.py
+++ b/api/models.py
@@ -3,6 +3,10 @@ from django.db import models
 
 # Create your models here.
 class Order(models.Model):
-    # Add your model here
-    pass
+    order_number = models.AutoField(primary_key=True)
+    total_price = models.DecimalField(max_digits=10, decimal_places=2)
+    created_time = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return self.order_number
 

--- a/api/models.py
+++ b/api/models.py
@@ -1,12 +1,20 @@
 from django.db import models
 
+class Product(models.Model) :
+    id = models.AutoField(primary_key=True)
+    name = models.CharField(max_length=255)
+    price = models.DecimalField(max_digits=10, decimal_places=2)
 
-# Create your models here.
+    def __str__(self):
+        return str(self.name)
+
 class Order(models.Model):
     order_number = models.AutoField(primary_key=True)
+    product =  models.ForeignKey(Product, on_delete=models.CASCADE, related_name="orders")
+    product_amount = models.IntegerField()
     total_price = models.DecimalField(max_digits=10, decimal_places=2)
     created_time = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
-        return self.order_number
+        return str(self.order_number)
 

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,8 +1,115 @@
 from django.test import TestCase
 from rest_framework.test import APITestCase
+from rest_framework import status
+from api.models import Product, Order
+from decimal import Decimal
 
-
-# Create your tests here.
 class OrderTestCase(APITestCase):
-    # Add your testcase here
-    pass
+
+    def setUp(self):
+        self.superuser_token = 'omni_pretest_superuser_token'
+        self.normal_token = 'omni_pretest_token'
+
+        self.product = Product.objects.create(
+            name='iPhone 15',
+            price=Decimal('29900.00')
+        )
+
+    def test_import_order_success(self):
+        data = {
+            'product_id': self.product.id,
+            'product_amount': 2
+        }
+        response = self.client.post(
+            '/api/import-order/',
+            data,
+            HTTP_AUTHORIZATION=f'Bearer {self.normal_token}'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        result = response.json()
+        self.assertEqual(result['product_id'], self.product.id)
+        self.assertEqual(result['product_amount'], 2)
+        self.assertEqual(result['total_price'], '59800.00')
+
+        self.assertEqual(Order.objects.count(), 1)
+
+
+    def test_import_order_product_not_found(self):
+        data = {
+            'product_id': 99999,
+            'product_amount': 2
+        }
+        response = self.client.post(
+            '/api/import-order/',
+            data,
+            HTTP_AUTHORIZATION=f'Bearer {self.normal_token}'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()['error'], 'Product not found')
+
+    def test_import_order_invalid_amount(self):
+        data = {
+            'product_id': self.product.id,
+            'product_amount': -5
+        }
+        response = self.client.post(
+            '/api/import-order/',
+            data,
+            HTTP_AUTHORIZATION=f'Bearer {self.normal_token}'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('error', response.json())
+
+    def test_import_order_missing_product_id(self):
+        data = {'product_amount': 2}
+        response = self.client.post(
+            '/api/import-order/',
+            data,
+            HTTP_AUTHORIZATION=f'Bearer {self.normal_token}'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()['error'], 'product_id is required')
+
+    def test_import_order_without_auth(self):
+        data = {
+            'product_id': self.product.id,
+            'product_amount': 2
+        }
+        response = self.client.post('/api/import-order/', data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_get_orders_success(self):
+        Order.objects.create(
+            product=self.product,
+            product_amount=3,
+            total_price=Decimal('89700.00')
+        )
+
+        response = self.client.get(
+            '/api/get-orders/',
+            HTTP_AUTHORIZATION=f'Bearer {self.superuser_token}'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        orders = response.json()
+        self.assertIsInstance(orders, list)
+        self.assertEqual(len(orders), 1)
+        self.assertEqual(orders[0]['product_amount'], 3)
+
+    def test_get_orders_with_normal_token(self):
+        response = self.client.get(
+            '/api/get-orders/',
+            HTTP_AUTHORIZATION=f'Bearer {self.normal_token}'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_get_orders_without_auth(self):
+        response = self.client.get('/api/get-orders/')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/api/urls.py
+++ b/api/urls.py
@@ -4,5 +4,6 @@ from api.views import import_order, health_check
 
 urlpatterns = [
     path('import-order/', import_order),
+    path('import-product/', import_product),
     path('health-check/', health_check),
 ]

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
 from django.urls import path
-from api.views import import_order
+from api.views import import_order, health_check
 
 urlpatterns = [
-    path('import-order/', import_order)
+    path('import-order/', import_order),
+    path('health-check/', health_check),
 ]

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,9 +1,11 @@
 from django.contrib import admin
 from django.urls import path
-from api.views import import_order, health_check
+from api.views import import_order, health_check, import_product, get_orders, get_products
 
 urlpatterns = [
     path('import-order/', import_order),
     path('import-product/', import_product),
     path('health-check/', health_check),
+    path('get-orders/', get_orders),
+    path('get-products/', get_products),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -100,3 +100,28 @@ def import_product(request):
         "name": product.name,
         "price": str(product.price)
     }, status=200)
+
+# clients get all products
+@api_view(['GET'])
+@require_api_token([ACCEPTED_TOKEN, SUPERUSER_TOKEN])
+def get_products(request):
+
+    products = Product.objects.all()
+    return JsonResponse([{
+        "id": product.id,
+        "name": product.name,
+        "price": str(product.price)
+    } for product in products], safe=False)
+
+@api_view(['GET'])
+@require_api_token([SUPERUSER_TOKEN])
+def get_orders(request):
+    orders = Order.objects.all()
+    return JsonResponse([{
+        "order_number": order.order_number,
+        "product_id": order.product.id,
+        "product_name": order.product.name,
+        "product_amount": order.product_amount,
+        "total_price": order.total_price,
+        "created_time": order.created_time,
+    } for order in orders], safe=False)

--- a/api/views.py
+++ b/api/views.py
@@ -1,8 +1,12 @@
 from django.shortcuts import render
-from django.http import HttpResponseBadRequest
+from django.http import HttpResponseBadRequest, JsonResponse, HttpResponse
 from rest_framework.decorators import api_view
+from decimal import Decimal, InvalidOperation
+from api.models import Order
 # Create your views here.
 
+def health_check(request):
+    return HttpResponse('Hello world')
 
 ACCEPTED_TOKEN = ('omni_pretest_token')
 

--- a/api/views.py
+++ b/api/views.py
@@ -13,5 +13,29 @@ ACCEPTED_TOKEN = ('omni_pretest_token')
 
 @api_view(['POST'])
 def import_order(request):
-    # Add your code here
-    return HttpResponseBadRequest()
+
+    total_price = request.data.get('total_price')
+    if total_price is None :        
+        return JsonResponse(
+            {"error": "total_price must be a valid decimal number"},
+            status=400
+        )
+
+    try : 
+        total_price = Decimal(total_price)
+
+    except(InvalidOperation, TypeError) :
+        return JsonResponse(
+            {"error": "total_price must be a valid decimal number"},
+            status=400
+        )
+    
+    order = Order.objects.create(total_price=total_price)
+    
+    return JsonResponse({
+        "message": "Order imported successfully",
+        "order_number": order.order_number,
+        "total_price": str(order.total_price),
+        "created_time": order.created_time,
+    }, status=200)
+

--- a/api/views.py
+++ b/api/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render
 from django.http import HttpResponseBadRequest, JsonResponse, HttpResponse
 from rest_framework.decorators import api_view
 from decimal import Decimal, InvalidOperation
-from api.models import Order
+from api.models import Order, Product
 # Create your views here.
 
 def health_check(request):
@@ -10,18 +10,20 @@ def health_check(request):
 
 ACCEPTED_TOKEN = ('omni_pretest_token')
 
-def require_api_token(view_func):
-    def _wrapped_view(request, *args, **kwargs):
-        auth_header = request.headers.get('Authorization')
-        if not auth_header or not auth_header.startswith("Bearer "):
-            return HttpResponseBadRequest('Missing or invalid Authorization header')
+def require_api_token(tokens):
+    def decorator(view_func):
+        def _wrapped_view(request, *args, **kwargs):
+            auth_header = request.headers.get('Authorization')
+            if not auth_header or not auth_header.startswith("Bearer "):
+                return HttpResponseBadRequest('Missing or invalid Authorization header')
 
-        token = auth_header.split(" ")[1]
-        if token != ACCEPTED_TOKEN:
-            return HttpResponseBadRequest('Invalid Access Token')
+            token = auth_header.split(" ")[1]
+            if token not in tokens :
+                return HttpResponseBadRequest('Invalid Access Token')
 
-        return view_func(request, *args, **kwargs)
-    return _wrapped_view
+            return view_func(request, *args, **kwargs)
+        return _wrapped_view
+    return decorator
 
 
 @api_view(['POST'])

--- a/api/views.py
+++ b/api/views.py
@@ -10,8 +10,22 @@ def health_check(request):
 
 ACCEPTED_TOKEN = ('omni_pretest_token')
 
+def require_api_token(view_func):
+    def _wrapped_view(request, *args, **kwargs):
+        auth_header = request.headers.get('Authorization')
+        if not auth_header or not auth_header.startswith("Bearer "):
+            return HttpResponseBadRequest('Missing or invalid Authorization header')
+
+        token = auth_header.split(" ")[1]
+        if token != ACCEPTED_TOKEN:
+            return HttpResponseBadRequest('Invalid Access Token')
+
+        return view_func(request, *args, **kwargs)
+    return _wrapped_view
+
 
 @api_view(['POST'])
+@require_api_token
 def import_order(request):
 
     total_price = request.data.get('total_price')

--- a/api/views.py
+++ b/api/views.py
@@ -26,32 +26,77 @@ def require_api_token(tokens):
     return decorator
 
 
+# clients make orders
 @api_view(['POST'])
-@require_api_token
+@require_api_token([ACCEPTED_TOKEN, SUPERUSER_TOKEN])
 def import_order(request):
 
-    total_price = request.data.get('total_price')
-    if total_price is None :        
-        return JsonResponse(
-            {"error": "total_price must be a valid decimal number"},
-            status=400
-        )
+    product_id = request.data.get('product_id')
+    product_amount = request.data.get('product_amount')
 
-    try : 
-        total_price = Decimal(total_price)
+    if not product_id:
+        return JsonResponse({"error": "product_id is required"}, status=400)
 
-    except(InvalidOperation, TypeError) :
-        return JsonResponse(
-            {"error": "total_price must be a valid decimal number"},
-            status=400
-        )
+    try:
+        product_id = int(product_id)
+        if product_id <= 0:
+            return JsonResponse({"error": "product_id must be a positive integer"}, status=400)
+    except (ValueError, TypeError):
+        return JsonResponse({"error": "product_id must be an integer"}, status=400)
     
-    order = Order.objects.create(total_price=total_price)
-    
+    try:
+        product_amount = int(product_amount)
+        if product_amount <= 0:
+            return JsonResponse({"error": "product_amount must be greater than 0"}, status=400)
+    except (ValueError, TypeError):
+        return JsonResponse({"error": "product_amount must be an integer"}, status=400)
+
+    try:
+        product = Product.objects.get(id=product_id)
+    except Product.DoesNotExist:
+        return JsonResponse({"error": "Product not found"}, status=400)
+
+    total_price = product.price * product_amount
+
+    order = Order.objects.create(
+        product=product,
+        product_amount=product_amount,
+        total_price=total_price
+    )
+
     return JsonResponse({
         "message": "Order imported successfully",
         "order_number": order.order_number,
-        "total_price": str(order.total_price),
+        "product_id": product.id,
+        "product_name": product.name,
+        "product_amount": order.product_amount,
+        "total_price": order.total_price,
         "created_time": order.created_time,
     }, status=200)
 
+
+
+# superuser add products
+@api_view(['POST'])
+@require_api_token([SUPERUSER_TOKEN])
+def import_product(request):
+    name = request.data.get('name')
+    price = request.data.get('price')
+
+    if not name or not name.strip():
+        return JsonResponse({"error": "Product name is required"}, status=400)
+
+    try:
+        price = Decimal(price)
+        if price <= 0:
+            return JsonResponse({"error": "Price must be greater than 0"}, status=400)
+    except (InvalidOperation, TypeError):
+        return JsonResponse({"error": "Invalid price value"}, status=400)
+
+    product = Product.objects.create(name=name.strip(), price=price)
+
+    return JsonResponse({
+        "id": product.id,
+        "name": product.name,
+        "price": str(product.price)
+    }, status=200)

--- a/api/views.py
+++ b/api/views.py
@@ -9,6 +9,7 @@ def health_check(request):
     return HttpResponse('Hello world')
 
 ACCEPTED_TOKEN = ('omni_pretest_token')
+SUPERUSER_TOKEN = ('omni_pretest_superuser_token')
 
 def require_api_token(tokens):
     def decorator(view_func):
@@ -69,6 +70,7 @@ def import_order(request):
         "order_number": order.order_number,
         "product_id": product.id,
         "product_name": product.name,
+        "product_price": product.price,
         "product_amount": order.product_amount,
         "total_price": order.total_price,
         "created_time": order.created_time,
@@ -121,6 +123,7 @@ def get_orders(request):
         "order_number": order.order_number,
         "product_id": order.product.id,
         "product_name": order.product.name,
+        "product_price": order.product.price,
         "product_amount": order.product_amount,
         "total_price": order.total_price,
         "created_time": order.created_time,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
    
 services:
   db:
-    image: postgres
+    image: postgres:16
     volumes:
       - ./data/db:/var/lib/postgresql/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - .:/code
+      - ./logs:/code/logs
     ports:
       - "8008:8008"
     environment:

--- a/pretest/settings.py
+++ b/pretest/settings.py
@@ -138,3 +138,56 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# Logging configuration
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '[{levelname}] {asctime} {module} {message}',
+            'style': '{',
+        },
+        'simple': {
+            'format': '{levelname} {message}',
+            'style': '{',
+        },
+    },
+    'handlers': {
+        'file': {
+            'level': 'INFO',
+            'class': 'logging.FileHandler',
+            'filename': os.path.join(BASE_DIR, 'logs/app.log'),
+            'formatter': 'verbose',
+        },
+        'error_file': {
+            'level': 'ERROR',
+            'class': 'logging.FileHandler',
+            'filename': os.path.join(BASE_DIR, 'logs/error.log'),
+            'formatter': 'verbose',
+        },
+        'request_file': {
+            'level': 'INFO',
+            'class': 'logging.FileHandler',
+            'filename': os.path.join(BASE_DIR, 'logs/request.log'),
+            'formatter': 'verbose',
+        },
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'simple',
+        },
+    },
+    'loggers': {
+        'api': {
+            'handlers': ['request_file', 'error_file', 'console'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'django': {
+            'handlers': ['file', 'console'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+    },
+}

--- a/pretest/settings.py
+++ b/pretest/settings.py
@@ -38,6 +38,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'api',
+    'rest_framework',
+    'drf_yasg',
 ]
 
 MIDDLEWARE = [
@@ -103,6 +105,19 @@ AUTH_PASSWORD_VALIDATORS = [
         'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
 ]
+
+
+SWAGGER_SETTINGS = {
+    'SECURITY_DEFINITIONS': {
+        'Bearer': {
+            'type': 'apiKey',
+            'in': 'header',
+            'name': 'Authorization',
+            'description': 'Input Token（Need Bearer prefix!!!）',
+        }
+    },
+    'USE_SESSION_AUTH': False, 
+}
 
 
 # Internationalization

--- a/pretest/urls.py
+++ b/pretest/urls.py
@@ -14,9 +14,25 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path, include, re_path
+from rest_framework import permissions
+from rest_framework.authentication import TokenAuthentication   
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="Pretest API",
+        default_version='v1',
+        description="API documentation for Pretest backend",
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include('api.urls')),   
+    path("swagger/", schema_view.with_ui('swagger', cache_timeout=0), name="schema-swagger-ui"),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 django==4.2.8
 djangorestframework==3.14.0
-psycopg2==2.9.9 ; platform_machine != "aarch64"
-psycopg2-binary==2.9.9 ; platform_machine == "aarch64"
+# psycopg2==2.9.9 ; platform_machine != "aarch64"
+# psycopg2-binary==2.9.9 ; platform_machine == "aarch64"
+drf-yasg==1.21.5
+psycopg2-binary==2.9.9

--- a/run_web.sh
+++ b/run_web.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+mkdir -p /code/logs
 sh wait-for-postgres.sh db
 python manage.py makemigrations api
 python manage.py migrate

--- a/run_web.sh
+++ b/run_web.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 sh wait-for-postgres.sh db
+python manage.py makemigrations api
 python manage.py migrate
 python manage.py runserver 0.0.0.0:8008


### PR DESCRIPTION
Hi, my name is Pai. I applied an engineer job in beBit and received this pretest. I did some modifications on this project and would simply explain what I have done in my PR. 

# Background
In this project, I created two roles : normal user(consumer) and superuser(shop owner), and they have different authorization levels. I did implement 5 APIs -- health-check, get-orders, get-products, import-order, import-product. Normal users have access with get-products and import-order, while superuser has access to call all APIs.  
 
I added a **swagger** interface, so interviewers can clearly understand the input and output format of each APIs.  In backend development, debugging and logging are very important, so I added a log record in **/logs**.  
<img width="1915" height="994" alt="image" src="https://github.com/user-attachments/assets/b495859c-6ef8-4052-a383-c3eb45bd74fd" />
<img width="1441" height="875" alt="image" src="https://github.com/user-attachments/assets/a869d8b5-72d7-42e5-87df-d25a5f16545d" />

# Database 
I have a Order and a Product table.  According to the requirements, I set Order.product_id as a foreign to connection with Product.id. I used order_number, and id as primary key for each table(auto increment).  
<img width="500" height="237" alt="image" src="https://github.com/user-attachments/assets/019246bb-e448-4040-8047-af41da4a85ee" />

# APIs

## token
Mention to token, I was not pretty sure what does  `ACCEPTED_TOKEN = ('omni_pretest_token')` means, so I just seem it as a simple token, not related to JWT or cryptography. I add another token `SUPERUSER_TOKEN = ('omni_pretest_superuser_token')` as superuser's token. 

In frontend, users have to put their token in request header `Authentication: Bearer <token>` so I can catch it with my `require_api_token` decorator and do some string comparisons. For each API, I can decide to open to different people in this way `@require_api_token(valid token list)`. For example, `@require_api_token([SUPERUSER_TOKEN])` is only exposed to superuser.

## [Get] Get Proudct/Order
Pretty pure, these two are simply get information from two table. In commercial perspective, users might want a platform to see all products, and shop owner always wants to see how many orders they receive.  

## [POST] Import Product
This API allows superusers to add newproducts to the catalog. It validates the product name and price, then stores the product information in the database.

 **Request Body**:
  - name: Product name (required, non-empty string)
  - price: Product price (required, positive decimal)

  **Authentication**: Bearer token (superuser only)

  **Response**: Product object with id, name, and price

## [POST] Import Order
 This API enables clients to create orders for existing products. It validates that the product exists, checks the order quantity
  is valid, and automatically calculates the total price based on product price and quantity.

**Request Body**:
  - product_id: ID of the product to order (required, positive integer)
  - product_amount: Quantity to order (required, positive integer)

  **Validation**:
  - Product must exist in database
  - Quantity must be a positive integer
  - Auto-calculates total_price = product.price × product_amount

  **Authentication**: Bearer token (normal user or superuser)

  **Response**: Order details including order_number, product info, product_amount, and total_price


# Test
I did some test in import-order and get-products API:

- normal import order call
- get product list
- order an product which doesn't exist
- order negative number products.
- order without product_id
- order without auth


# Additional information

I did some changes in docker-compose file and Dockerfile. All of them are about idicating specific versions of python and postgres. The reason is that when I tried to build up my docker-compose container, the lastest versions (the default version if you don't specify one) always causes some problems. For example, postgres:18 somehow has different default data storage place with previous images. 

I also met some issues with psycopg2 (not pretty sure is this my environment problem?), so I just directly used binary version.  

 